### PR TITLE
'source' current directory's `defaults` and remove `-k` option from `redis` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Note the rootfs contents were copied beforehand.
 ```
 $ cp -r ../static-pie-apps/redis/rootfs/* rootfs/
 
-$ ./run_elfloader -n -k ../static-pie-apps/redis/redis-server redis.conf
+$ ./run_elfloader -n ../static-pie-apps/redis/redis-server redis.conf
 
 Creating bridge uk0 if it does not exist ...
 Adding IP address 172.44.0.1 to bridge uk0 ...

--- a/run_elfloader
+++ b/run_elfloader
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source defaults
+source ./defaults
 
 usage()
 {


### PR DESCRIPTION
This PR makes sure that the `run_elfloader` script uses only
the `defaults` file located in our current directory and removes
the `-k` option from the `README.md`'s `redis` example.

Signed-off-by: Sergiu Moga <sergiu.moga@protonmail.com>