### PR TITLE
Only run qemu-system-x86_64 as root when necessary

### DIFF
--- a/debug.sh
+++ b/debug.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 usage()
 {
@@ -28,7 +28,7 @@ while getopts "he:o:" OPT; do
     esac
 done
 
-shift $((${OPTIND}-1))
+shift $((OPTIND-1))
 
 if test "$#" -lt 1; then
     usage

--- a/defaults
+++ b/defaults
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 rootfs_9p="$PWD/rootfs/"
 kvm_image="$PWD/app-elfloader_kvm-x86_64"

--- a/run.sh
+++ b/run.sh
@@ -103,28 +103,28 @@ arguments="${arguments}-kernel $kvm_image "
 arguments="${arguments}-initrd $exec_to_load "
 
 if test "$use_kvm" -eq 1; then
-  file="/dev/kvm"
-  if ! [ -c "$file" ]; then
-    echo "$file does not exist, cannot run with KVM" 1>&2
-    exit 1
-  fi
-
-  # Check if the effective user has RW permission to /dev/kvm,
-  # if they haven't, temporarily add the user to the group that owns
-  # /dev/kvm, by default the KVM group. If that also fails, run QEMU
-  # as root, but with the -runas parameter to drop privileges.
-  if ! [ -r "$file" ] || ! [ -w "$file" ]; then
-    group_owner=$(stat -c "%G" $file)
-    if [ "$(stat -c "%A" $file | cut -c 5-6)" = "rw" ] && ! [ "$group_owner" = "$(id -un 0)" ];
-    then
-      sudo_prefix="sudo -g $group_owner -- "
-    else
-      sudo_prefix="sudo "
-      arguments="${arguments}-runas $USER "
+    file="/dev/kvm"
+    if ! [ -c "$file" ]; then
+      echo "$file does not exist, cannot run with KVM" 1>&2
+      exit 1
     fi
-  fi
 
-  arguments="${arguments}-enable-kvm -cpu host "
+    # Check if the effective user has RW permission to /dev/kvm,
+    # if they haven't, temporarily add the user to the group that owns
+    # /dev/kvm, by default the KVM group. If that also fails, run QEMU
+    # as root, but with the -runas parameter to drop privileges.
+    if ! [ -r "$file" ] || ! [ -w "$file" ]; then
+        group_owner=$(stat -c "%G" $file)
+        if [ "$(stat -c "%A" $file | cut -c 5-6)" = "rw" ] && ! [ "$group_owner" = "$(id -un 0)" ];
+        then
+            sudo_prefix="sudo -g $group_owner -- "
+        else
+            sudo_prefix="sudo "
+            arguments="${arguments}-runas $USER "
+        fi
+    fi
+
+    arguments="${arguments}-enable-kvm -cpu host "
 fi
 
 if test "$start_in_debug_mode" -eq 1; then

--- a/run.sh
+++ b/run.sh
@@ -105,7 +105,7 @@ arguments="${arguments}-initrd $exec_to_load "
 if test "$use_kvm" -eq 1; then
   file="/dev/kvm"
   if ! [ -c "$file" ]; then
-    echo "$file does not exist, cannot run with KVM" 2>&1
+    echo "$file does not exist, cannot run with KVM" 1>&2
     exit 1
   fi
 

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
-source ./defaults
+. ./defaults
 
 usage()
 {
@@ -40,14 +40,14 @@ setup_networking()
 
     # Configure network setup scripts.
     cat > "$net_up_script" <<END
-#!/bin/bash
+#!/bin/sh
 
 sudo ip link set dev "\$1" up
 sudo ip link set dev "\$1" master "$bridge_iface"
 END
 
     cat > "$net_down_script" <<END
-#!/bin/bash
+#!/bin/sh
 
 sudo ip link set dev "\$1" nomaster
 sudo ip link set dev "\$1" down
@@ -87,7 +87,7 @@ while getopts "dhngk:r:" OPT; do
     esac
 done
 
-shift $((${OPTIND}-1))
+shift $((OPTIND-1))
 
 if test "$#" -lt 1; then
     usage
@@ -97,30 +97,30 @@ exec_to_load="$1"
 shift
 
 arguments="-m 2G -nographic -nodefaults "
-arguments+="-display none -serial stdio -device isa-debug-exit "
-arguments+="-fsdev local,security_model=passthrough,id=hvirtio0,path=$rootfs_9p "
-arguments+="-device virtio-9p-pci,fsdev=hvirtio0,mount_tag=fs0 "
-arguments+="-kernel $kvm_image "
-arguments+="-initrd $exec_to_load "
+arguments="${arguments}-display none -serial stdio -device isa-debug-exit "
+arguments="${arguments}-fsdev local,security_model=passthrough,id=hvirtio0,path=$rootfs_9p "
+arguments="${arguments}-device virtio-9p-pci,fsdev=hvirtio0,mount_tag=fs0 "
+arguments="${arguments}-kernel $kvm_image "
+arguments="${arguments}-initrd $exec_to_load "
 
 if test "$use_kvm" -eq 1; then
-    arguments+="-enable-kvm -cpu host "
+    arguments="${arguments}-enable-kvm -cpu host "
 fi
 
 if test "$start_in_debug_mode" -eq 1; then
-    arguments+="-s -S "
+    arguments="${arguments}-s -S "
 fi
 
 if test "$use_networking" -eq 1; then
     setup_networking
-    arguments+="-netdev tap,id=hnet0,vhost=off,script=$net_up_script,downscript=$net_down_script -device virtio-net-pci,netdev=hnet0,id=net0 "
-    arguments+="-append \"$net_args -- $*\" "
+    arguments="${arguments}-netdev tap,id=hnet0,vhost=off,script=$net_up_script,downscript=$net_down_script -device virtio-net-pci,netdev=hnet0,id=net0 "
+    arguments="${arguments}-append \"$net_args -- $*\" "
 else
-    arguments+="-append \"-- $*\" "
+    arguments="${arguments}-append \"-- $*\" "
 fi
 
 # Start QEMU VM.
 echo "Running command: "
-echo "sudo qemu-system-x86_64 "$arguments""
+echo sudo qemu-system-x86_64 "$arguments"
 echo ""
 eval sudo qemu-system-x86_64 "$arguments"

--- a/run_app.sh
+++ b/run_app.sh
@@ -121,27 +121,27 @@ run_redis()
 
 available_applications()
 {
-  grep -E "^run_.+\(\)\$" "$0" | sed 's/()//' | sed 's/run_//' | sort
+    grep -E "^run_.+\(\)\$" "$0" | sed 's/()//' | sed 's/run_//' | sort
 }
 
 print_available_apps()
 {
-  printf "Possible apps:\n%s" "$(available_applications | tr '\n' ' ' | fold -s)"
+    printf "Possible apps:\n%s" "$(available_applications | tr '\n' ' ' | fold -s)"
 }
 
 if test $# -ne 1; then
-  echo "Usage: $0 <app>"
-  print_available_apps
-  echo 1>&2
-  exit 1
+    echo "Usage: $0 <app>"
+    print_available_apps
+    echo 1>&2
+    exit 1
 fi
 
 app="$1"
 
 if available_applications | grep -x "$app" >/dev/null; then
-  run_"$app"
+    run_"$app"
 else
-  echo "Unknown app '$app', don't know how to run it" 1>&2
-  print_available_apps
-  exit 1
+    echo "Unknown app '$app', don't know how to run it" 1>&2
+    print_available_apps
+    exit 1
 fi

--- a/run_app.sh
+++ b/run_app.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 run_helloworld_static()
 {
@@ -119,27 +119,29 @@ run_redis()
     ./run.sh -n -r ../dynamic-apps/redis/ /lib64/ld-linux-x86-64.so.2 /usr/bin/redis-server /etc/redis/redis.conf
 }
 
-apps=("helloworld_static" "server_static" "helloworld_go_static" "server_go_static" "helloworld_cpp_static" "helloworld_rust_static_musl" "helloworld_rust_static_gnu" "nginx_static" "redis_static" "sqlite3" "bc_static" "gzip_static")
-apps+=("helloworld" "server" "helloworld_go" "server_go" "helloworld_cpp" "helloworld_rust" "nginx" "redis" "sqlite3" "bc" "gzip")
+available_applications()
+{
+  grep -E "^run_.+\(\)\$" "$0" | sed 's/()//' | sed 's/run_//' | sort
+}
+
+print_available_apps()
+{
+  printf "Possible apps:\n%s" "$(available_applications | tr '\n' ' ' | fold -s)"
+}
+
 if test $# -ne 1; then
-    echo "Usage: $0 <app>" 1>&2
-    echo 1>&2
-    echo "Possible apps: ${apps[@]}" 1>&2
-    exit 1
+  echo "Usage: $0 <app>"
+  print_available_apps
+  echo 1>&2
+  exit 1
 fi
 
 app="$1"
 
-if [[ ! " ${apps[*]} " =~ " $app " ]]; then
-    echo "Unknown app $app" 1>&2
-    echo 1>&2
-    echo "Possible apps: ${apps[@]}" 1>&2
-    exit 1
+if available_applications | grep -x "$app" >/dev/null; then
+  run_"$app"
+else
+  echo "Unknown app '$app', don't know how to run it" 1>&2
+  print_available_apps
+  exit 1
 fi
-
-if test ! "$(type -t run_"$app")" = "function"; then
-    echo "Don't know how to run $app" 1>&2
-    exit 1
-fi
-
-run_"$app"


### PR DESCRIPTION
It is not always necessary to run qemu as the root user. If the user is added to the kvm group, then it generally has access to `/dev/kvm/` already. In case the user doesn't have access to `/dev/kvm`, then qemu is run as sudo with the `-runas` flag, which drops root privileges before guest execution is started.