### PR TITLE
run.sh: Use security model none for the root filesystem

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -101,7 +101,7 @@ exec_to_load="$1"
 
 arguments="-m 2G -nographic -nodefaults "
 arguments="${arguments}-display none -serial stdio -device isa-debug-exit "
-arguments="${arguments}-fsdev local,security_model=passthrough,id=hvirtio0,path=$rootfs_9p "
+arguments="${arguments}-fsdev local,security_model=none,id=hvirtio0,path=$rootfs_9p "
 arguments="${arguments}-device virtio-9p-pci,fsdev=hvirtio0,mount_tag=fs0 "
 arguments="${arguments}-kernel $kvm_image "
 


### PR DESCRIPTION
The `passthrough` security model will attempt to create files on the
host using the same uid as the one on the guest, by calling `fchown`,
which will fail if `qemu` is not called as root.

Fix that by using security model `none`, which will still call the
`fchown`, but ignore the returned error.

This will solve issue [unikraft/#933](https://github.com/unikraft/run-app-elfloader/issues/16).

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>
